### PR TITLE
Fix: 'Container' object has no attribute 'st_info'

### DIFF
--- a/src/impelf.py
+++ b/src/impelf.py
@@ -25,8 +25,8 @@ def get_imported_symbols_and_libraries(elf_file):
     for section in elf_file.iter_sections():
         if isinstance(section, SymbolTableSection):
             for symbol in section.iter_symbols():
-               if symbol.name and symbol.entry.st_info.type == 'STT_FUNC':
-                  imported_symbols.append(symbol.name)
+                if symbol.name and symbol.entry.st_info.type == 'STT_FUNC':
+                    imported_symbols.append(symbol.name)
 
     return imported_symbols, libraries
 

--- a/src/impelf.py
+++ b/src/impelf.py
@@ -2,6 +2,7 @@ import sys
 import hashlib
 from elftools.elf.elffile import ELFFile
 from elftools.elf.dynamic import DynamicSection
+from elftools.elf.sections import SymbolTableSection
 
 def is_elf_binary(file):
     magic_bytes = file.read(4)
@@ -22,10 +23,10 @@ def get_imported_symbols_and_libraries(elf_file):
                     break
 
     for section in elf_file.iter_sections():
-        if hasattr(section, 'iter_symbols'):
+        if isinstance(section, SymbolTableSection):
             for symbol in section.iter_symbols():
-                if symbol.name and symbol.entry.st_info.type == 'STT_FUNC':
-                    imported_symbols.append(symbol.name)
+               if symbol.name and symbol.entry.st_info.type == 'STT_FUNC':
+                  imported_symbols.append(symbol.name)
 
     return imported_symbols, libraries
 


### PR DESCRIPTION
Section ".gnu.version" don't have st_info attribute. It's better to operate only in '.dynsym' section.
```
Traceback (most recent call last):
  File "/home/agresor/impelf.py", line 54, in <module>
    main()
  File "/home/agresor/impelf.py", line 48, in main
    imported_symbols, libraries = get_imported_symbols_and_libraries(elf_file)
  File "/home/agresor/impelf.py", line 27, in get_imported_symbols_and_libraries
    if symbol.name and symbol.entry.st_info.type == 'STT_FUNC':
AttributeError: 'Container' object has no attribute 'st_info'
```