### PR TITLE
Fix: 'ELFFile' object has no attribute 'get_section_by_offset'

### DIFF
--- a/src/impelf.py
+++ b/src/impelf.py
@@ -17,9 +17,6 @@ def get_imported_symbols_and_libraries(elf_file):
             for tag in section.iter_tags():
                 if tag.entry.d_tag == 'DT_NEEDED':
                     libraries.append(tag.needed)
-                elif tag.entry.d_tag == 'DT_STRTAB':
-                    string_table = elf_file.get_section_by_offset(tag.entry.d_val)
-                    break
 
     for section in elf_file.iter_sections():
         if hasattr(section, 'iter_symbols'):


### PR DESCRIPTION
string_table is never used in code and 'ELFFile' object has no attribute 'get_section_by_offset' ( pyelftools==0.30 ).
```
Traceback (most recent call last):
  File "/home/agresor/impelf.py", line 54, in <module>
    main()
  File "/home/agresor/impelf.py", line 48, in main
    imported_symbols, libraries = get_imported_symbols_and_libraries(elf_file)
  File "/home/agresor/impelf.py", line 21, in get_imported_symbols_and_libraries
    string_table = elf_file.get_section_by_offset(tag.entry.d_val)
AttributeError: 'ELFFile' object has no attribute 'get_section_by_offset'. Did you mean: 'get_section_by_name'?
```